### PR TITLE
Migrate explore euid flyouts thi

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/common/components/tables/helpers.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/common/components/tables/helpers.tsx
@@ -4,22 +4,24 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import React, { useCallback, useMemo, useState } from 'react';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import {
-  EuiLink,
-  EuiPopover,
-  EuiToolTip,
-  EuiText,
-  EuiTextColor,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
+  EuiPopover,
+  EuiText,
+  EuiTextColor,
+  EuiToolTip,
   useEuiFontSize,
   useEuiTheme,
 } from '@elastic/eui';
 import { SECURITY_CELL_ACTIONS_DEFAULT } from '@kbn/ui-actions-plugin/common/trigger_ids';
-import { SecurityCellActions, CellActionsMode } from '../cell_actions';
+import { CellActionsMode, SecurityCellActions } from '../cell_actions';
 import { escapeDataProviderId } from '../drag_and_drop/helpers';
 import { defaultToEmptyTag, getEmptyTagValue } from '../empty_value';
 import { MoreRowItems } from '../page';
@@ -30,19 +32,6 @@ interface GetRowItemsWithActionsParams {
   fieldName: string;
   idPrefix: string;
   render?: (item: string) => JSX.Element;
-  displayCount?: number;
-  maxOverflow?: number;
-}
-
-export interface RowItemWithEntityIdentifiers {
-  value: string;
-}
-
-interface GetRowItemsWithActionsForEntitiesParams {
-  items: RowItemWithEntityIdentifiers[] | null | undefined;
-  fieldName: string;
-  idPrefix: string;
-  render: (item: RowItemWithEntityIdentifiers) => JSX.Element;
   displayCount?: number;
   maxOverflow?: number;
 }
@@ -94,120 +83,6 @@ export const getRowItemsWithActions = ({
     return getEmptyTagValue();
   }
 };
-
-export const getRowItemsWithActionsForEntities = ({
-  items,
-  fieldName,
-  idPrefix,
-  render,
-  displayCount = 5,
-  maxOverflow = 5,
-}: GetRowItemsWithActionsForEntitiesParams): JSX.Element => {
-  if (items != null && items.length > 0) {
-    const visibleItems = items.slice(0, displayCount).map((item, index) => {
-      const id = escapeDataProviderId(`${idPrefix}-${fieldName}-${item.value}-${index}`);
-      return (
-        <SecurityCellActions
-          key={id}
-          mode={CellActionsMode.HOVER_DOWN}
-          visibleCellActions={5}
-          showActionTooltips
-          triggerId={SECURITY_CELL_ACTIONS_DEFAULT}
-          data={{
-            value: item.value,
-            field: fieldName,
-          }}
-        >
-          <>{render(item)}</>
-        </SecurityCellActions>
-      );
-    });
-
-    return visibleItems.length > 0 ? (
-      <>
-        {visibleItems}{' '}
-        <RowItemOverflowForEntities
-          fieldName={fieldName}
-          items={items}
-          idPrefix={idPrefix}
-          overflowIndexStart={displayCount}
-          maxOverflowItems={maxOverflow}
-          render={render}
-        />
-      </>
-    ) : (
-      getEmptyTagValue()
-    );
-  } else {
-    return getEmptyTagValue();
-  }
-};
-
-interface RowItemOverflowForEntitiesProps {
-  fieldName: string;
-  items: RowItemWithEntityIdentifiers[];
-  idPrefix: string;
-  overflowIndexStart: number;
-  maxOverflowItems: number;
-  render: (item: RowItemWithEntityIdentifiers) => React.ReactNode;
-}
-
-const RowItemOverflowForEntitiesComponent: React.FC<RowItemOverflowForEntitiesProps> = ({
-  fieldName,
-  items,
-  idPrefix,
-  overflowIndexStart = 5,
-  maxOverflowItems = 5,
-  render,
-}) => {
-  const { euiTheme } = useEuiTheme();
-  const maxVisibleItems = useMemo(
-    () => items.slice(0, maxOverflowItems + 1),
-    [items, maxOverflowItems]
-  );
-  return (
-    <>
-      {items.length > overflowIndexStart && (
-        <Popover count={items.length - overflowIndexStart} idPrefix={idPrefix}>
-          <EuiText size="xs">
-            <MoreContainer
-              fieldName={fieldName}
-              idPrefix={idPrefix}
-              values={maxVisibleItems.map((i) => i.value)}
-              overflowIndexStart={overflowIndexStart}
-              moreMaxHeight="none"
-              render={(value) => {
-                const item = items.find((i) => i.value === value);
-                return item ? render(item) : defaultToEmptyTag(value);
-              }}
-            />
-          </EuiText>
-          {items.length > overflowIndexStart + maxOverflowItems && (
-            <EuiFlexGroup
-              css={{ paddingTop: euiTheme.size.m }}
-              data-test-subj="popover-additional-overflow"
-            >
-              <EuiFlexItem>
-                <EuiText size="xs">
-                  <EuiTextColor color="subdued">
-                    {items.length - overflowIndexStart - maxOverflowItems}{' '}
-                    <FormattedMessage
-                      data-test-subj="popover-additional-overflow-text"
-                      id="xpack.securitySolution.tables.rowItemHelper.moreDescription"
-                      defaultMessage="more not shown"
-                    />
-                  </EuiTextColor>
-                </EuiText>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          )}
-        </Popover>
-      )}
-    </>
-  );
-};
-RowItemOverflowForEntitiesComponent.displayName = 'RowItemOverflowForEntitiesComponent';
-const RowItemOverflowForEntities = React.memo(RowItemOverflowForEntitiesComponent);
 
 interface RowItemOverflowProps {
   fieldName: string;
@@ -305,6 +180,13 @@ const PopoverComponent: React.FC<PopoverComponentProps> = ({ children, count, id
             />
           </EuiLink>
         }
+        aria-label={i18n.translate(
+          'xpack.securitySolution.tables.rowItemHelper.overflowButtonAriaLabel',
+          {
+            defaultMessage: 'Show {count} more items',
+            values: { count },
+          }
+        )}
         closePopover={() => setIsOpen(!isOpen)}
         id={`${idPrefix}-popover`}
         isOpen={isOpen}

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
@@ -30,7 +30,8 @@ import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import { buildEuidCspPreviewOptions } from '../../../../cloud_security_posture/utils/build_euid_csp_preview_options';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useNonClosedAlerts } from '../../../../cloud_security_posture/hooks/use_non_closed_alerts';
-import { buildHostNamesFilter, RiskSeverity } from '../../../../../common/search_strategy';
+import type { RiskSeverity } from '../../../../../common/search_strategy';
+import { buildHostNamesFilter } from '../../../../../common/search_strategy';
 import { HOST_NAME_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import { useDocumentDetailsContext } from '../../shared/context';
@@ -51,7 +52,7 @@ import { RiskScoreLevel } from '../../../../entity_analytics/components/severity
 import { useSourcererDataView } from '../../../../sourcerer/containers';
 import { useGlobalTime } from '../../../../common/containers/use_global_time';
 import { useHostDetails } from '../../../../explore/hosts/containers/hosts/details';
-import { getField } from '../../shared/utils';
+import { getField, isRiskSeverity, normalizeRiskLevel } from '../../shared/utils';
 import { CellActions } from '../../shared/components/cell_actions';
 import {
   FAMILY,
@@ -80,16 +81,6 @@ import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_sel
 
 const HOST_ICON = 'storage';
 const HOST_ENTITY_OVERVIEW_ID = 'host-entity-overview';
-const VALID_RISK_SEVERITIES: ReadonlyArray<RiskSeverity> = Object.values(RiskSeverity);
-
-const isRiskSeverity = (value: string): value is RiskSeverity =>
-  VALID_RISK_SEVERITIES.includes(value as RiskSeverity);
-
-const normalizeRiskLevel = (level: string | undefined): RiskSeverity | null => {
-  if (level == null || level === '') return null;
-  const normalized = level.charAt(0).toUpperCase() + level.slice(1).toLowerCase();
-  return isRiskSeverity(normalized) ? normalized : isRiskSeverity(level) ? level : null;
-};
 
 export interface HostEntityOverviewProps {
   /**

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
@@ -30,7 +30,7 @@ import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import { buildEuidCspPreviewOptions } from '../../../../cloud_security_posture/utils/build_euid_csp_preview_options';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useNonClosedAlerts } from '../../../../cloud_security_posture/hooks/use_non_closed_alerts';
-import { buildHostNamesFilter } from '../../../../../common/search_strategy';
+import { buildHostNamesFilter, RiskSeverity } from '../../../../../common/search_strategy';
 import { HOST_NAME_FIELD_NAME } from '../../../../timelines/components/timeline/body/renderers/constants';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
 import { useDocumentDetailsContext } from '../../shared/context';
@@ -77,17 +77,10 @@ import { AlertCountInsight } from '../../shared/components/alert_count_insight';
 import { useNavigateToHostDetails } from '../../../entity_details/host_right/hooks/use_navigate_to_host_details';
 import { DETECTION_RESPONSE_ALERTS_BY_STATUS_ID } from '../../../../overview/components/detection_response/alerts_by_status/types';
 import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_selected_patterns';
-import type { RiskSeverity } from '../../../../../common/search_strategy';
 
 const HOST_ICON = 'storage';
 const HOST_ENTITY_OVERVIEW_ID = 'host-entity-overview';
-const VALID_RISK_SEVERITIES: readonly RiskSeverity[] = [
-  'Unknown',
-  'Low',
-  'Moderate',
-  'High',
-  'Critical',
-] as const;
+const VALID_RISK_SEVERITIES: ReadonlyArray<RiskSeverity> = Object.values(RiskSeverity);
 
 const isRiskSeverity = (value: string): value is RiskSeverity =>
   VALID_RISK_SEVERITIES.includes(value as RiskSeverity);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
@@ -23,7 +23,8 @@ import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/u
 import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
 import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import { buildEuidCspPreviewOptions } from '../../../../cloud_security_posture/utils/build_euid_csp_preview_options';
-import { buildUserNamesFilter, RiskSeverity } from '../../../../../common/search_strategy';
+import type { RiskSeverity } from '../../../../../common/search_strategy';
+import { buildUserNamesFilter } from '../../../../../common/search_strategy';
 import type { ESQuery } from '../../../../../common/typed_json';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useNonClosedAlerts } from '../../../../cloud_security_posture/hooks/use_non_closed_alerts';
@@ -33,7 +34,12 @@ import { getRiskFromEntityRecord } from '../../../entity_details/shared/entity_s
 import { PreferenceFormattedDateFromPrimitive } from '../../../../common/components/formatted_date';
 import type { DescriptionList } from '../../../../../common/utility_types';
 import type { IdentityFields } from '../../shared/utils';
-import { getField, mergeLegacyIdentityWhenStoreEntityMissing } from '../../shared/utils';
+import {
+  getField,
+  isRiskSeverity,
+  mergeLegacyIdentityWhenStoreEntityMissing,
+  normalizeRiskLevel,
+} from '../../shared/utils';
 import { CellActions } from '../../shared/components/cell_actions';
 import {
   FirstLastSeen,
@@ -73,16 +79,6 @@ import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_sel
 
 const USER_ICON = 'user';
 const USER_ENTITY_OVERVIEW_ID = 'user-entity-overview';
-const VALID_RISK_SEVERITIES: ReadonlyArray<RiskSeverity> = Object.values(RiskSeverity);
-
-const isRiskSeverity = (value: string): value is RiskSeverity =>
-  VALID_RISK_SEVERITIES.includes(value as RiskSeverity);
-
-const normalizeRiskLevel = (level: string | undefined): RiskSeverity | null => {
-  if (level == null || level === '') return null;
-  const normalized = level.charAt(0).toUpperCase() + level.slice(1).toLowerCase();
-  return isRiskSeverity(normalized) ? normalized : isRiskSeverity(level) ? level : null;
-};
 
 export interface UserEntityOverviewProps {
   userName: string;

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
@@ -23,8 +23,7 @@ import { useHasMisconfigurations } from '@kbn/cloud-security-posture/src/hooks/u
 import { FF_ENABLE_ENTITY_STORE_V2, useEntityStoreEuidApi } from '@kbn/entity-store/public';
 import { useUiSetting } from '@kbn/kibana-react-plugin/public';
 import { buildEuidCspPreviewOptions } from '../../../../cloud_security_posture/utils/build_euid_csp_preview_options';
-import { buildUserNamesFilter } from '../../../../../common/search_strategy';
-import type { RiskSeverity } from '../../../../../common/search_strategy';
+import { buildUserNamesFilter, RiskSeverity } from '../../../../../common/search_strategy';
 import type { ESQuery } from '../../../../../common/typed_json';
 import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useNonClosedAlerts } from '../../../../cloud_security_posture/hooks/use_non_closed_alerts';
@@ -74,13 +73,7 @@ import { useSelectedPatterns } from '../../../../data_view_manager/hooks/use_sel
 
 const USER_ICON = 'user';
 const USER_ENTITY_OVERVIEW_ID = 'user-entity-overview';
-const VALID_RISK_SEVERITIES: readonly RiskSeverity[] = [
-  'Unknown',
-  'Low',
-  'Moderate',
-  'High',
-  'Critical',
-] as const;
+const VALID_RISK_SEVERITIES: ReadonlyArray<RiskSeverity> = Object.values(RiskSeverity);
 
 const isRiskSeverity = (value: string): value is RiskSeverity =>
   VALID_RISK_SEVERITIES.includes(value as RiskSeverity);

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils.test.tsx
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import type { GetFieldsData } from './hooks/use_get_fields_data';
 import {
   getField,
   getFieldArray,
-  getEventTitle,
-  getAlertTitle,
   mergeLegacyIdentityWhenStoreEntityMissing,
   resolveHostNameForEntityInsights,
   resolveUserNameForEntityInsights,
@@ -57,36 +56,6 @@ describe('getFieldArray', () => {
   });
 });
 
-describe('getEventTitle', () => {
-  it('should return event title based on category when event kind is event', () => {
-    expect(
-      getEventTitle({
-        eventKind: 'event',
-        eventCategory: 'process',
-        getFieldsData: (field: string) => (field === 'process.name' ? 'process name' : ''),
-      })
-    ).toBe('process name');
-  });
-
-  it('should return External alert details when event kind is alert', () => {
-    expect(
-      getEventTitle({ eventKind: 'alert', eventCategory: null, getFieldsData: jest.fn() })
-    ).toBe('External alert details');
-  });
-
-  it('should return generic event details when event kind is not event or alert', () => {
-    expect(
-      getEventTitle({ eventKind: 'metric', eventCategory: null, getFieldsData: jest.fn() })
-    ).toBe('Metric details');
-  });
-
-  it('should return Event details when event kind is null', () => {
-    expect(getEventTitle({ eventKind: null, eventCategory: null, getFieldsData: jest.fn() })).toBe(
-      'Event details'
-    );
-  });
-});
-
 const emptyGetFieldsData: GetFieldsData = () => [];
 
 describe('resolveUserNameForEntityInsights', () => {
@@ -127,16 +96,6 @@ describe('resolveHostNameForEntityInsights', () => {
     expect(resolveHostNameForEntityInsights({ 'host.id': 'uuid-host' }, emptyGetFieldsData)).toBe(
       'uuid-host'
     );
-  });
-});
-
-describe('getAlertTitle', () => {
-  it('should return Document details when ruleName is undefined', () => {
-    expect(getAlertTitle({ ruleName: undefined })).toBe('Document details');
-  });
-
-  it('should return ruleName when ruleName is defined', () => {
-    expect(getAlertTitle({ ruleName: 'test rule' })).toBe('test rule');
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils.test.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils.test.tsx
@@ -9,7 +9,9 @@ import type { GetFieldsData } from './hooks/use_get_fields_data';
 import {
   getField,
   getFieldArray,
+  isRiskSeverity,
   mergeLegacyIdentityWhenStoreEntityMissing,
+  normalizeRiskLevel,
   resolveHostNameForEntityInsights,
   resolveUserNameForEntityInsights,
 } from './utils';
@@ -96,6 +98,53 @@ describe('resolveHostNameForEntityInsights', () => {
     expect(resolveHostNameForEntityInsights({ 'host.id': 'uuid-host' }, emptyGetFieldsData)).toBe(
       'uuid-host'
     );
+  });
+});
+
+describe('isRiskSeverity', () => {
+  it('returns true for valid severity values', () => {
+    expect(isRiskSeverity('Unknown')).toBe(true);
+    expect(isRiskSeverity('Low')).toBe(true);
+    expect(isRiskSeverity('Moderate')).toBe(true);
+    expect(isRiskSeverity('High')).toBe(true);
+    expect(isRiskSeverity('Critical')).toBe(true);
+  });
+
+  it('returns false for unrecognised values', () => {
+    expect(isRiskSeverity('critical')).toBe(false);
+    expect(isRiskSeverity('CRITICAL')).toBe(false);
+    expect(isRiskSeverity('')).toBe(false);
+    expect(isRiskSeverity('invalid')).toBe(false);
+  });
+});
+
+describe('normalizeRiskLevel', () => {
+  it('returns null for empty or undefined input', () => {
+    expect(normalizeRiskLevel(undefined)).toBeNull();
+    expect(normalizeRiskLevel('')).toBeNull();
+  });
+
+  it('normalises lowercase input', () => {
+    expect(normalizeRiskLevel('critical')).toBe('Critical');
+    expect(normalizeRiskLevel('high')).toBe('High');
+    expect(normalizeRiskLevel('moderate')).toBe('Moderate');
+    expect(normalizeRiskLevel('low')).toBe('Low');
+    expect(normalizeRiskLevel('unknown')).toBe('Unknown');
+  });
+
+  it('normalises uppercase input', () => {
+    expect(normalizeRiskLevel('CRITICAL')).toBe('Critical');
+    expect(normalizeRiskLevel('HIGH')).toBe('High');
+  });
+
+  it('passes through already-canonical values', () => {
+    expect(normalizeRiskLevel('Critical')).toBe('Critical');
+    expect(normalizeRiskLevel('High')).toBe('High');
+  });
+
+  it('returns null for unrecognised values', () => {
+    expect(normalizeRiskLevel('extreme')).toBeNull();
+    expect(normalizeRiskLevel('none')).toBeNull();
   });
 });
 

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { GetFieldsData } from './hooks/use_get_fields_data';
+import { RiskSeverity } from '../../../../common/search_strategy';
 
 /**
  * Helper function to retrieve a field's value (used in combination with the custom hook useGetFieldsData (x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/hooks/use_get_fields_data.ts)
@@ -162,5 +163,23 @@ export const resolveHostNameForEntityInsightsWithFallback = (
 ): string | undefined =>
   resolveHostNameForEntityInsights(identityFields, getFieldsData) ??
   firstNonEmptyIdentityValue(identityFields);
+
+const VALID_RISK_SEVERITIES: ReadonlyArray<RiskSeverity> = Object.values(RiskSeverity);
+
+/**
+ * Returns true when the given string is a valid {@link RiskSeverity} value.
+ */
+export const isRiskSeverity = (value: string): value is RiskSeverity =>
+  VALID_RISK_SEVERITIES.includes(value as RiskSeverity);
+
+/**
+ * Normalises a raw risk level string (e.g. 'critical', 'CRITICAL') to the
+ * canonical {@link RiskSeverity} casing, or returns null when unrecognised.
+ */
+export const normalizeRiskLevel = (level: string | undefined): RiskSeverity | null => {
+  if (level == null || level === '') return null;
+  const normalized = level.charAt(0).toUpperCase() + level.slice(1).toLowerCase();
+  return isRiskSeverity(normalized) ? normalized : isRiskSeverity(level) ? level : null;
+};
 
 export { ecsSliceToFlattenedDocument } from './utils/ecs_slice_to_flattened_document';

--- a/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/flyout/document_details/shared/utils.tsx
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import { i18n } from '@kbn/i18n';
-import { startCase } from 'lodash';
 import type { GetFieldsData } from './hooks/use_get_fields_data';
 
 /**
@@ -36,76 +34,6 @@ export const getFieldArray = (field: unknown | unknown[]) => {
     return field;
   }
   return [];
-};
-
-// mapping of event category to the field displayed as title
-export const EVENT_CATEGORY_TO_FIELD: Record<string, string> = {
-  authentication: 'user.name',
-  configuration: '',
-  database: '',
-  driver: '',
-  email: '',
-  file: 'file.name',
-  host: 'host.name',
-  iam: '',
-  intrusion_detection: '',
-  malware: '',
-  network: '',
-  package: '',
-  process: 'process.name',
-  registry: '',
-  session: '',
-  threat: '',
-  vulnerability: '',
-  web: '',
-};
-
-/**
- * Helper function to retrieve the alert title
- */
-export const getAlertTitle = ({ ruleName }: { ruleName?: string | null }) => {
-  const defaultAlertTitle = i18n.translate(
-    'xpack.securitySolution.flyout.right.header.headerTitle',
-    { defaultMessage: 'Document details' }
-  );
-  return ruleName ?? defaultAlertTitle;
-};
-
-/**
- * Helper function to retrieve the event title
- */
-export const getEventTitle = ({
-  eventKind,
-  eventCategory,
-  getFieldsData,
-}: {
-  eventKind: string | null;
-  eventCategory: string | null;
-  getFieldsData: GetFieldsData;
-}) => {
-  const defaultTitle = i18n.translate('xpack.securitySolution.flyout.title.eventTitle', {
-    defaultMessage: `Event details`,
-  });
-
-  if (eventKind === 'event' && eventCategory) {
-    const fieldName = EVENT_CATEGORY_TO_FIELD[eventCategory];
-    return getField(getFieldsData(fieldName)) ?? defaultTitle;
-  }
-
-  if (eventKind === 'alert') {
-    return i18n.translate('xpack.securitySolution.flyout.title.alertEventTitle', {
-      defaultMessage: 'External alert details',
-    });
-  }
-
-  return eventKind
-    ? i18n.translate('xpack.securitySolution.flyout.title.otherEventTitle', {
-        defaultMessage: '{eventKind} details',
-        values: {
-          eventKind: startCase(eventKind),
-        },
-      })
-    : defaultTitle;
 };
 
 /**
@@ -153,10 +81,42 @@ const HOST_DISPLAY_FIELD_PRIORITY: readonly string[] = ['host.name', 'host.hostn
 const USER_ID_FIELD_KEYS = new Set(['user.id', 'entity.id']);
 const HOST_ID_FIELD_KEYS = new Set(['host.id', 'entity.id']);
 
+const isNonEmpty = (v: string | undefined): v is string => v != null && v.trim() !== '';
+
 const firstNonEmptyIdentityValue = (
   identityFields: IdentityFields | undefined
-): string | undefined =>
-  Object.values(identityFields ?? {}).find((v) => typeof v === 'string' && v.trim() !== '');
+): string | undefined => Object.values(identityFields ?? {}).find(isNonEmpty);
+
+const resolveEntityName = (
+  identityFields: IdentityFields | undefined,
+  getFieldsData: GetFieldsData,
+  displayPriority: readonly string[],
+  idFieldKeys: ReadonlySet<string>,
+  fallbackIdKeys: readonly string[]
+): string | undefined => {
+  for (const field of displayPriority) {
+    const fromDoc = getField(getFieldsData(field));
+    if (fromDoc) return fromDoc;
+  }
+  if (identityFields) {
+    for (const field of displayPriority) {
+      const v = identityFields[field];
+      if (isNonEmpty(v)) return v;
+    }
+    const sortedKeys = Object.keys(identityFields).sort();
+    for (const key of sortedKeys) {
+      if (!idFieldKeys.has(key) && !key.endsWith('.id')) {
+        const v = identityFields[key];
+        if (isNonEmpty(v)) return v;
+      }
+    }
+    for (const key of fallbackIdKeys) {
+      const v = identityFields[key];
+      if (isNonEmpty(v)) return v;
+    }
+  }
+  return undefined;
+};
 
 /**
  * Value to pass into observed-user queries and flyout headers: prefer ECS names from the document
@@ -165,38 +125,14 @@ const firstNonEmptyIdentityValue = (
 export const resolveUserNameForEntityInsights = (
   identityFields: IdentityFields | undefined,
   getFieldsData: GetFieldsData
-): string | undefined => {
-  for (const field of USER_DISPLAY_FIELD_PRIORITY) {
-    const fromDoc = getField(getFieldsData(field));
-    if (fromDoc) {
-      return fromDoc;
-    }
-  }
-  if (identityFields) {
-    for (const field of USER_DISPLAY_FIELD_PRIORITY) {
-      const v = identityFields[field];
-      if (typeof v === 'string' && v.trim() !== '') {
-        return v;
-      }
-    }
-    const sortedKeys = Object.keys(identityFields).sort();
-    for (const key of sortedKeys) {
-      if (!USER_ID_FIELD_KEYS.has(key) && !key.endsWith('.id')) {
-        const v = identityFields[key];
-        if (typeof v === 'string' && v.trim() !== '') {
-          return v;
-        }
-      }
-    }
-    for (const key of ['user.id', 'entity.id'] as const) {
-      const v = identityFields[key];
-      if (typeof v === 'string' && v.trim() !== '') {
-        return v;
-      }
-    }
-  }
-  return undefined;
-};
+): string | undefined =>
+  resolveEntityName(
+    identityFields,
+    getFieldsData,
+    USER_DISPLAY_FIELD_PRIORITY,
+    USER_ID_FIELD_KEYS,
+    ['user.id', 'entity.id']
+  );
 
 /**
  * Same as {@link resolveUserNameForEntityInsights} for host panels (host.name before host.id).
@@ -204,38 +140,14 @@ export const resolveUserNameForEntityInsights = (
 export const resolveHostNameForEntityInsights = (
   identityFields: IdentityFields | undefined,
   getFieldsData: GetFieldsData
-): string | undefined => {
-  for (const field of HOST_DISPLAY_FIELD_PRIORITY) {
-    const fromDoc = getField(getFieldsData(field));
-    if (fromDoc) {
-      return fromDoc;
-    }
-  }
-  if (identityFields) {
-    for (const field of HOST_DISPLAY_FIELD_PRIORITY) {
-      const v = identityFields[field];
-      if (typeof v === 'string' && v.trim() !== '') {
-        return v;
-      }
-    }
-    const sortedKeys = Object.keys(identityFields).sort();
-    for (const key of sortedKeys) {
-      if (!HOST_ID_FIELD_KEYS.has(key) && !key.endsWith('.id')) {
-        const v = identityFields[key];
-        if (typeof v === 'string' && v.trim() !== '') {
-          return v;
-        }
-      }
-    }
-    for (const key of ['host.id', 'entity.id'] as const) {
-      const v = identityFields[key];
-      if (typeof v === 'string' && v.trim() !== '') {
-        return v;
-      }
-    }
-  }
-  return undefined;
-};
+): string | undefined =>
+  resolveEntityName(
+    identityFields,
+    getFieldsData,
+    HOST_DISPLAY_FIELD_PRIORITY,
+    HOST_ID_FIELD_KEYS,
+    ['host.id', 'entity.id']
+  );
 
 export const resolveUserNameForEntityInsightsWithFallback = (
   identityFields: IdentityFields | undefined,


### PR DESCRIPTION
## Summary

This PR fixes a couple of small things on the main PR:
- remove unused code
- remove unwanted re-added coded during a recent rebase/merge
- removed some constants in favor of existing code
- extracted some logic into shared functions for less code duplication

I ran a few commands locally to make sure things were not introducing any issues:

Typescheck is ✅ 
<img width="1014" height="59" alt="Screenshot 2026-03-26 at 4 21 38 PM" src="https://github.com/user-attachments/assets/f705389e-42bb-4efb-9e8d-6cf4507884ba" />

Flyout folder tests are ✅ 
<img width="839" height="85" alt="Screenshot 2026-03-26 at 4 26 39 PM" src="https://github.com/user-attachments/assets/4c1eef00-87c4-4b5e-9b2f-f061bcc58c09" />

Flyout_v2 folder tests are ✅ 
<img width="733" height="86" alt="Screenshot 2026-03-26 at 4 27 17 PM" src="https://github.com/user-attachments/assets/f81f5f84-b59c-4a94-8ccf-d90c13470001" />
