### PR TITLE
Remove `workflow_execute_step` + `kibana.request guidance` from threat intel agent docs

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
@@ -138,10 +138,11 @@ export const THREAT_INTEL_TOOL_IDS = {
    * One-call orchestrated hunt that chains the tradecraft-style two-tier
    * model: Tier 1 (`hunt_for_threat`, atomic IOC lookups) → Tier 2
    * (`hunt_behavior`, LLM-refined behavioral rules with the affected-asset
-   * context from Tier 1 fed into the prompt). Agents call this directly
-   * through the tool surface; native Workflows call the matching HTTP
-   * route when they need both tiers without encoding the chaining
-   * themselves.
+   * context from Tier 1 fed into the prompt). Workflows (digest delivery,
+   * hit provenance backfill) call this directly via the internal HTTP
+   * route so they get Tier 2 without having to encode the chaining
+   * themselves; the granular tools remain available on the registry for
+   * power-user / LLM-driven control flows.
    */
   huntOrchestrated: 'threat_intel.hunt_orchestrated',
   /**
@@ -169,7 +170,8 @@ export const THREAT_INTEL_TOOL_IDS = {
 export const THREAT_INTELLIGENCE_API_BASE = '/api/threat_intelligence' as const;
 
 /**
- * Domain action routes. Each path is consumed by exactly one route handler in
+ * Domain action routes — these are the canonical execution surface of the
+ * skill. Each path is consumed by exactly one route handler in
  * `server/routes/` and by exactly one shared service module in
  * `server/services/`.
  */

--- a/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
@@ -138,11 +138,10 @@ export const THREAT_INTEL_TOOL_IDS = {
    * One-call orchestrated hunt that chains the tradecraft-style two-tier
    * model: Tier 1 (`hunt_for_threat`, atomic IOC lookups) → Tier 2
    * (`hunt_behavior`, LLM-refined behavioral rules with the affected-asset
-   * context from Tier 1 fed into the prompt). Workflows (digest delivery,
-   * hit provenance backfill) call this directly via the internal HTTP
-   * route so they get Tier 2 without having to encode the chaining
-   * themselves; the granular tools remain available on the registry for
-   * power-user / LLM-driven control flows.
+   * context from Tier 1 fed into the prompt). Agents call this directly
+   * through the tool surface; native Workflows call the matching HTTP
+   * route when they need both tiers without encoding the chaining
+   * themselves.
    */
   huntOrchestrated: 'threat_intel.hunt_orchestrated',
   /**
@@ -162,18 +161,15 @@ export const THREAT_INTEL_TOOL_IDS = {
  * Public HTTP routes owned by this plugin.
  *
  * Every domain action exposes a versioned route at
- * `/api/threat_intelligence/<action>`. The Agent Builder skill markdown
- * documents these routes; the orchestrating agent invokes them via
- * `execute_workflow_step` with `kibana-request`. The same routes are
- * callable from ECLI, workflows, MCP clients, and other HTTP integrations.
- * Inline tools are thin portability wrappers that delegate to the shared
- * service modules these routes call.
+ * `/api/threat_intelligence/<action>`. Native Workflows, UI surfaces, and
+ * future ecli callers use these HTTP contracts directly. Agent Builder
+ * skills use the direct `threat_intel.*` tools, which validate compact
+ * arguments and delegate to the same shared service modules these routes call.
  */
 export const THREAT_INTELLIGENCE_API_BASE = '/api/threat_intelligence' as const;
 
 /**
- * Domain action routes — these are the canonical execution surface of the
- * skill. Each path is consumed by exactly one Express route handler in
+ * Domain action routes. Each path is consumed by exactly one route handler in
  * `server/routes/` and by exactly one shared service module in
  * `server/services/`.
  */

--- a/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
@@ -171,7 +171,7 @@ export const THREAT_INTELLIGENCE_API_BASE = '/api/threat_intelligence' as const;
 
 /**
  * Domain action routes — these are the canonical execution surface of the
- * skill. Each path is consumed by exactly one route handler in
+ * skill. Each path is consumed by exactly one Express route handler in
  * `server/routes/` and by exactly one shared service module in
  * `server/services/`.
  */

--- a/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
@@ -162,10 +162,12 @@ export const THREAT_INTEL_TOOL_IDS = {
  * Public HTTP routes owned by this plugin.
  *
  * Every domain action exposes a versioned route at
- * `/api/threat_intelligence/<action>`. Native Workflows, UI surfaces, and
- * future ecli callers use these HTTP contracts directly. Agent Builder
- * skills use the direct `threat_intel.*` tools, which validate compact
- * arguments and delegate to the same shared service modules these routes call.
+ * `/api/threat_intelligence/<action>`. Native Workflows and UI surfaces use
+ * these HTTP contracts directly. Agent Builder skills use the direct
+ * `threat_intel.*` tools, which validate compact arguments and delegate to the
+ * same shared service modules these routes call. When `ecli` becomes available
+ * in Agent Builder it will call these routes directly and the inline tools will
+ * be superseded.
  */
 export const THREAT_INTELLIGENCE_API_BASE = '/api/threat_intelligence' as const;
 

--- a/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
@@ -239,7 +239,8 @@ export const SAVED_VIEWS_API_PATH = `${THREAT_INTELLIGENCE_API_BASE}/saved_views
  * current alert to `.kibana-threat-reports*` via Layer 1 indicator reference
  * and/or Layer 2 MITRE technique overlap (see RFC 0002).
  */
-export const FLYOUT_INSIGHTS_API_PATH = `${THREAT_INTELLIGENCE_API_BASE}/flyout_insights` as const;
+export const FLYOUT_INSIGHTS_API_PATH =
+  `${THREAT_INTELLIGENCE_API_BASE}/flyout_insights` as const;
 
 /**
  * Saved-object type for `threat-intelligence-saved-view`. The

--- a/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
+++ b/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/hub/constants.ts
@@ -239,8 +239,7 @@ export const SAVED_VIEWS_API_PATH = `${THREAT_INTELLIGENCE_API_BASE}/saved_views
  * current alert to `.kibana-threat-reports*` via Layer 1 indicator reference
  * and/or Layer 2 MITRE technique overlap (see RFC 0002).
  */
-export const FLYOUT_INSIGHTS_API_PATH =
-  `${THREAT_INTELLIGENCE_API_BASE}/flyout_insights` as const;
+export const FLYOUT_INSIGHTS_API_PATH = `${THREAT_INTELLIGENCE_API_BASE}/flyout_insights` as const;
 
 /**
  * Saved-object type for `threat-intelligence-saved-view`. The

--- a/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/skill/skill_kibana.md
+++ b/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/skill/skill_kibana.md
@@ -1,18 +1,13 @@
-## Architecture: Routes Are the Canonical Execution Surface
+## Architecture: Tools Are the Agent Execution Surface
 
-This skill documents public HTTP routes; **execution happens through
-`execute_workflow_step` with `kibana-request`**. Business logic lives in
-the plugin's shared service modules (`server/services/`) behind those
-routes. The same routes are also callable from ECLI, workflow steps, and
-3rd party agents — no rework required as new callers appear.
+Agent execution happens through the `threat_intel.*` tools. The tools are thin
+wrappers that validate compact arguments and delegate to the plugin's shared
+service modules (`server/services/`). Do **not** generate workflow YAML or call
+`workflow_execute_step` / `kibana.request` for these skill actions.
 
-The inline tool list (`threat_intel.search_reports`, etc.) is a
-**thin portability wrapper** for agents that can't reach Kibana APIs
-natively (Claude, Cursor). They delegate to the same shared services
-these routes call. **Inside Kibana, prefer the routes.**
-
-The agent should invoke routes with `execute_workflow_step` using a `kibana-request`
-step (`method: POST`, `path: <one of below>`, `body: { ... }`).
+The same shared services also sit behind public HTTP routes. Native Workflows,
+UI surfaces, and future `ecli` callers use those routes directly; Agent Builder
+skills should use the direct tools listed below.
 
 ## Rich attachments (inline Canvas UI)
 
@@ -63,7 +58,7 @@ timeline, category breakdown, report cards, environment impact) scoped to the sa
 
 ### For digest queries ("what's new on X this week?")
 
-1. Call `threat_intel.search_reports` (or `POST /api/threat_intelligence/search_reports`) **immediately**
+1. Call `threat_intel.search_reports` **immediately**
    with `query` = the user's topic, `time_range` = last 7 days unless they specified
    otherwise, `sort_by: "rank"`, `size: 10`. Map ransomware / supply chain topics to
    `categories: ["ransomware", "supply-chain"]` only on the first attempt; retry without
@@ -73,14 +68,14 @@ timeline, category breakdown, report cards, environment impact) scoped to the sa
 3. Optionally call `threat_intel.synthesize_advisory` for a 2–3 paragraph
    executive lede in prose (do not put the lede in a `text` attachment).
 4. Optionally `threat-intel-mitre-heatmap` when techniques are present; `threat-intel-severity-timeline` when the window is wider than 7 days.
-5. For high/critical hits only, optionally `POST /api/threat_intelligence/hunt_behavior` — do not block
+5. For high/critical hits only, optionally call `threat_intel.hunt_behavior` — do not block
    the digest on hunt/extraction calls.
 6. Only when `total` is 0 after both search attempts: offer paste-ingest, feed setup, or
    subscription (subscription flow below).
 
 ### For coverage-gap queries ("what's hot that I don't cover?")
 
-1. Call `threat_intel.coverage_gap` (or `POST /api/threat_intelligence/coverage_gap`) with
+1. Call `threat_intel.coverage_gap` with
    the user's time range and any tag/source filters they specified.
 2. When `techniques.length > 0`: copy the `renderTag` from the tool result verbatim so the
    `threat-intel-mitre-heatmap` Canvas renders (see **Rich attachments**). Uncovered techniques
@@ -89,7 +84,7 @@ timeline, category breakdown, report cards, environment impact) scoped to the sa
    - `enable_existing`: recommend enabling the disabled rule(s) in
      `matching_disabled_rule_ids` (Detection Engine bulk-enable) — do
      **not** call `security.create_detection_rule`.
-   - `create_rule`: call `POST /api/threat_intelligence/hunt_behavior` on the
+   - `create_rule`: call `threat_intel.hunt_behavior` on the
      underlying reports, then propose a durable rule via
      `security.create_detection_rule`.
    - `covered`: no action required.
@@ -108,15 +103,13 @@ timeline, category breakdown, report cards, environment impact) scoped to the sa
    `/api/threat_intelligence/subscriptions/submit` so the agent does
    NOT need to be re-invoked. Only persist directly (POST to the submit
    route from the agent) when acting non-interactively.
-4. For listing or removing subscriptions, issue
-   `POST /api/threat_intelligence/subscriptions/list` or
-   `POST /api/threat_intelligence/subscriptions/delete`.
+4. For listing or removing subscriptions, use `threat_intel.manage_subscriptions`
+   with `action: "list"` or `action: "delete"`.
 
-## Portability Tools (3rd party agents only)
+## Threat Intelligence Tools
 
-For agents that can't reach Kibana APIs natively, the same surface is
-available as Agent Builder tools that delegate to the exact same shared
-services these routes call:
+Use these Agent Builder tools for skill execution. They delegate to the same
+shared services as the HTTP routes:
 
 - `threat_intel.search_reports`
 - `threat_intel.ingest_report`
@@ -130,6 +123,5 @@ services these routes call:
 - `threat_intel.extract_iocs` (registry)
 - `threat_intel.analyse_environment` (registry)
 
-When invoked from inside Kibana, these tools merely re-execute the
-service the corresponding route uses. Inside Kibana orchestration, prefer
-the routes — the tools exist for portability.
+Native Workflow YAML may call the HTTP routes with `kibana.request`, but the
+agent should not route through `workflow_execute_step` to reach these services.

--- a/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/skill/skill_kibana.md
+++ b/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/skill/skill_kibana.md
@@ -1,13 +1,16 @@
-## Architecture: Tools Are the Agent Execution Surface
+## Architecture: Services Are the Canonical Execution Surface
 
-Agent execution happens through the `threat_intel.*` tools. The tools are thin
-wrappers that validate compact arguments and delegate to the plugin's shared
-service modules (`server/services/`). Do **not** generate workflow YAML or call
-`workflow_execute_step` / `kibana.request` for these skill actions.
+The shared service modules in `server/services/` are the single source of truth
+for every domain action. They are reached through two entry points:
 
-The same shared services also sit behind public HTTP routes. Native Workflows,
-UI surfaces, and future `ecli` callers use those routes directly; Agent Builder
-skills should use the direct tools listed below.
+- **Agent Builder tools** (`threat_intel.*`) — thin wrappers that validate compact
+  arguments and call the service directly. Agents should use these.
+- **HTTP routes** (`/api/threat_intelligence/<action>`) — expose the same services
+  over HTTP. Native Workflows reach them via `kibana.request`; `ecli` callers and
+  other HTTP integrations use these routes as well.
+
+Do **not** generate workflow YAML or route agent calls through
+`workflow_execute_step` + `kibana.request` — call the tools directly.
 
 ## Rich attachments (inline Canvas UI)
 

--- a/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/skill/skill_kibana.md
+++ b/x-pack/solutions/security/plugins/security_solution/common/threat_intelligence/skill/skill_kibana.md
@@ -6,8 +6,11 @@ for every domain action. They are reached through two entry points:
 - **Agent Builder tools** (`threat_intel.*`) — thin wrappers that validate compact
   arguments and call the service directly. Agents should use these.
 - **HTTP routes** (`/api/threat_intelligence/<action>`) — expose the same services
-  over HTTP. Native Workflows reach them via `kibana.request`; `ecli` callers and
-  other HTTP integrations use these routes as well.
+  over HTTP. Native Workflows reach them via `kibana.request`; other HTTP
+  integrations use these routes as well. When `ecli` becomes available in Agent
+  Builder it will invoke these routes directly, at which point the inline tools
+  will be removed — tools are intentionally kept inline (not user-visible) for
+  this reason.
 
 Do **not** generate workflow YAML or route agent calls through
 `workflow_execute_step` + `kibana.request` — call the tools directly.

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/analyse_environment.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/analyse_environment.ts
@@ -47,8 +47,8 @@ export const analyseEnvironmentTool: BuiltinToolDefinition<typeof analyseEnviron
     `Portability wrapper around POST ${ANALYSE_ENVIRONMENT_API_PATH}. ` +
     'Profile the customer environment to tailor threat-intelligence feed recommendations. ' +
     'Returns: (a) active integration data streams with hit counts; (b) the OS family mix ' +
-    '(windows / linux / macos); (c) the cloud-provider mix (aws / gcp / azure). Inside Kibana, ' +
-    'prefer calling the route directly via `execute_workflow_step` + `kibana-request`.',
+    '(windows / linux / macos); (c) the cloud-provider mix (aws / gcp / azure). Agent Builder ' +
+    'should call this tool directly; native Workflows and UI surfaces use the matching HTTP route.',
   schema: analyseEnvironmentSchema,
   tags: ['threat-intel', 'environment-profile'],
   handler: async (params, { esClient, logger }) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/coverage_gap.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/coverage_gap.ts
@@ -67,7 +67,8 @@ export const coverageGapTool: BuiltinSkillBoundedTool<typeof coverageGapSchema> 
     'from disabled rules that should be re-enabled (`coverage_recommendation: enable_existing`) ' +
     'versus techniques with no rule (`create_rule`). When techniques are returned, ' +
     'automatically stores a `threat-intel-mitre-heatmap` attachment (`mode: "coverage"`) and ' +
-    'includes a `renderTag` in the tool result. Inside Kibana, prefer the route via `kibana-request`.',
+    'includes a `renderTag` in the tool result. Agent Builder should call this tool directly; ' +
+    'native Workflows and UI surfaces use the matching HTTP route.',
   schema: coverageGapSchema,
   handler: async (params, { esClient, savedObjectsClient, logger, attachments }) => {
     try {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/extract_iocs.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/extract_iocs.ts
@@ -38,8 +38,8 @@ export const extractIocsTool: BuiltinToolDefinition<typeof extractIocsSchema> = 
   description:
     `Portability wrapper around POST ${EXTRACT_IOCS_API_PATH}. ` +
     'Extract IOCs (hashes, IPs, domains, URLs) from a block of text using conservative regexes. ' +
-    'Used by Workflow 2 during automated ingestion. Inside Kibana, prefer calling the route ' +
-    'directly via `execute_workflow_step` + `kibana-request`.',
+    'Used by native Workflows during automated ingestion. Agent Builder should call this tool ' +
+    'directly when IOC extraction is needed.',
   schema: extractIocsSchema,
   tags: ['threat-intel', 'ioc-extraction'],
   handler: async (params) => {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/generalize_from_telemetry.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/generalize_from_telemetry.ts
@@ -97,8 +97,8 @@ export const generalizeFromTelemetryTool: BuiltinSkillBoundedTool<
     'detection rules. A synthetic `source.type: "telemetry"` row is persisted to ' +
     '`.kibana-threat-reports-*` for provenance. Surviving candidates are returned with the ' +
     'same `proposed_esql_rule` + `threat-intel-finding-card` attachment-hint shape as ' +
-    '`hunt_behavior`. Inside Kibana, prefer calling the route directly via ' +
-    '`execute_workflow_step` + `kibana-request`.',
+    '`hunt_behavior`. Agent Builder should call this tool directly; native Workflows and UI ' +
+    'surfaces use the matching HTTP route.',
   schema: generalizeFromTelemetrySchema,
   handler: async (params, { esClient, logger, modelProvider, spaceId }) => {
     try {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/hunt_behavior.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/hunt_behavior.ts
@@ -55,8 +55,8 @@ export const huntBehaviorTool: BuiltinSkillBoundedTool<typeof huntBehaviorSchema
     'MITRE ATT&CK technique IDs with evidence quotes; (2) each candidate is validated against ' +
     'the vendored Kibana ATT&CK catalog. Hallucinated or unknown IDs are dropped. Surviving ' +
     'candidates return as behavioral findings with a `proposed_esql_rule` body and a pre-built ' +
-    '`threat-intel-finding-card` attachment hint. Inside Kibana, prefer calling the route ' +
-    'directly via `execute_workflow_step` + `kibana-request`.',
+    '`threat-intel-finding-card` attachment hint. Agent Builder should call this tool directly; ' +
+    'native Workflows and UI surfaces use the matching HTTP route.',
   schema: huntBehaviorSchema,
   handler: async (params, { logger, modelProvider }) => {
     try {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/hunt_for_threat.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/hunt_for_threat.ts
@@ -84,8 +84,8 @@ export const huntForThreatTool: BuiltinSkillBoundedTool<typeof huntForThreatSche
     `Portability wrapper around POST ${HUNT_FOR_THREAT_API_PATH}. ` +
     "Active forward hunt for a threat report's IOCs (and optional ATT&CK technique IDs) " +
     'across the customer environment. Returns top matching documents AND an `affected_assets` ' +
-    'aggregation (unique hosts + users). Inside Kibana, prefer calling the route directly via ' +
-    '`execute_workflow_step` + `kibana-request`.',
+    'aggregation (unique hosts + users). Agent Builder should call this tool directly; native ' +
+    'Workflows and UI surfaces use the matching HTTP route.',
   schema: huntForThreatSchema,
   handler: async (params, { esClient, logger }) => {
     try {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/hunt_orchestrator.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/hunt_orchestrator.ts
@@ -26,6 +26,10 @@ import { huntOrchestrated } from '../../../threat_intelligence/services';
  * surface for one-call workflows (digest delivery, hit provenance
  * backfill) and for 3rd party agents that prefer a single round-trip.
  *
+ * Agent Builder should call this tool directly. Native Workflows and UI
+ * surfaces use the matching HTTP route, and both entry points delegate to the
+ * same shared service.
+ *
  * The handler resolves the default model via `modelProvider` (same
  * pattern `hunt_behavior` uses) and threads it into the orchestrator;
  * when GenAI is unavailable, the model is intentionally omitted so the
@@ -133,8 +137,8 @@ export const huntOrchestratedTool: BuiltinSkillBoundedTool<typeof huntOrchestrat
     'both "what is currently hitting" AND "what durable rule would catch this in the future" ' +
     'from a single tool call — typical for digest synthesis and per-report deep-dive flows. ' +
     'When fine-grained control is needed, prefer the granular `hunt_for_threat` + ' +
-    '`hunt_behavior` tools. Inside Kibana orchestration, prefer calling the route directly ' +
-    'via `execute_workflow_step` + `kibana-request`.',
+    '`hunt_behavior` tools. Agent Builder should call this tool directly; native Workflows ' +
+    'and UI surfaces use the matching HTTP route.',
   schema: huntOrchestratedSchema,
   handler: async (params, { esClient, logger, modelProvider }) => {
     let model;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/ingest_report.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/ingest_report.ts
@@ -58,8 +58,8 @@ export const ingestReportTool: BuiltinSkillBoundedTool<typeof ingestReportSchema
     `Portability wrapper around POST ${INGEST_REPORT_API_PATH}. ` +
     'Ingest one threat intelligence report (analyst paste / ad-hoc URL / vendor advisory) ' +
     'into the source-agnostic `.kibana-threat-reports-*` data stream. The report is fingerprinted ' +
-    'for dedup so re-submitting the same content is a no-op. Inside Kibana, prefer calling the ' +
-    'route directly via `execute_workflow_step` + `kibana-request`.',
+    'for dedup so re-submitting the same content is a no-op. Agent Builder should call this ' +
+    'tool directly; native Workflows and UI surfaces use the matching HTTP route.',
   schema: ingestReportSchema,
   handler: async (params, { esClient, logger, spaceId }) => {
     try {

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/manage_subscriptions.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/manage_subscriptions.ts
@@ -134,8 +134,8 @@ export const manageSubscriptionsTool: BuiltinSkillBoundedTool<typeof manageSubsc
     `(${SUBMIT_SUBSCRIPTION_API_PATH}, ${LIST_SUBSCRIPTIONS_API_PATH}, ${DELETE_SUBSCRIPTION_API_PATH}). ` +
     'Three actions: `create` (propose or persist), `list` (inspect), `delete` (remove by id). ' +
     'For `create` with `confirm=false`, returns parameters for an editable confirmation card ' +
-    "that submits directly to the plugin's internal route. Inside Kibana, prefer calling the " +
-    'routes directly via `execute_workflow_step` + `kibana-request`.',
+    "that submits directly to the plugin's internal route. Agent Builder should call this " +
+    'tool directly; native Workflows and UI surfaces use the matching HTTP routes.',
   schema: manageSubscriptionsSchema,
   handler: async (input, { esClient, logger, spaceId }) => {
     const client = esClient.asCurrentUser;

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/search_reports.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/search_reports.ts
@@ -158,9 +158,7 @@ export const searchReportsTool: BuiltinSkillBoundedTool<typeof searchReportsSche
             type: ToolResultType.other,
             data: {
               ...data,
-              ...(renderTag
-                ? { renderTag, attachmentId: buildDigestReportTableAttachmentId(params) }
-                : {}),
+              ...(renderTag ? { renderTag, attachmentId: buildDigestReportTableAttachmentId(params) } : {}),
             },
           },
         ],

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/search_reports.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/search_reports.ts
@@ -158,7 +158,9 @@ export const searchReportsTool: BuiltinSkillBoundedTool<typeof searchReportsSche
             type: ToolResultType.other,
             data: {
               ...data,
-              ...(renderTag ? { renderTag, attachmentId: buildDigestReportTableAttachmentId(params) } : {}),
+              ...(renderTag
+                ? { renderTag, attachmentId: buildDigestReportTableAttachmentId(params) }
+                : {}),
             },
           },
         ],

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/search_reports.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/search_reports.ts
@@ -31,13 +31,10 @@ import {
 /**
  * Thin Agent Builder tool wrapper for the `search_reports` domain action.
  *
- * Per the Agent Builder architecture guidance, the canonical execution
- * surface is the internal HTTP route at `SEARCH_REPORTS_API_PATH` and the
- * orchestrating agent should prefer `execute_workflow_step` with
- * `kibana-request` against that route. This tool is retained only as a
- * portability surface for 3rd party agents (Claude, Cursor) that can't
- * reach Kibana APIs natively — it delegates to the same shared service
- * the route uses, so the two paths can never drift.
+ * Agent Builder calls this tool directly. The internal HTTP route at
+ * `SEARCH_REPORTS_API_PATH` remains the contract for native Workflows, UI
+ * surfaces, and future ecli callers. Both entry points delegate to the same
+ * shared service so the two paths cannot drift.
  */
 const searchReportsSchema = z.object({
   query: z

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/search_reports.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/search_reports.ts
@@ -32,9 +32,10 @@ import {
  * Thin Agent Builder tool wrapper for the `search_reports` domain action.
  *
  * Agent Builder calls this tool directly. The internal HTTP route at
- * `SEARCH_REPORTS_API_PATH` remains the contract for native Workflows, UI
- * surfaces, and future ecli callers. Both entry points delegate to the same
- * shared service so the two paths cannot drift.
+ * `SEARCH_REPORTS_API_PATH` remains the contract for native Workflows and UI
+ * surfaces. Both entry points delegate to the same shared service so the two
+ * paths cannot drift. When `ecli` becomes available in Agent Builder it will
+ * call the route directly and this tool will be superseded.
  */
 const searchReportsSchema = z.object({
   query: z

--- a/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/synthesize_advisory.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/agent_builder/tools/threat_intelligence/synthesize_advisory.ts
@@ -90,8 +90,8 @@ export const synthesizeAdvisoryTool: BuiltinSkillBoundedTool<typeof synthesizeAd
     '/ region, and asks the LLM to produce a 2-3 paragraph narrative + a short ' +
     'recommended-actions list. When `persist: true`, the advisory is written to the ' +
     '`.kibana-threat-intel-advisories` companion index for dashboard / digest consumption. ' +
-    'Inside Kibana orchestration, prefer calling the route directly via ' +
-    '`execute_workflow_step` + `kibana-request`.',
+    'Agent Builder should call this tool directly; native Workflows and UI surfaces use the ' +
+    'matching HTTP route.',
   schema: synthesizeAdvisorySchema,
   handler: async (params, { esClient, logger, modelProvider }) => {
     let model;
@@ -105,8 +105,8 @@ export const synthesizeAdvisoryTool: BuiltinSkillBoundedTool<typeof synthesizeAd
     try {
       // Agent Builder tools don't carry a request-scoped space — fall
       // back to the global sentinel so the service still works under
-      // single-space deployments. Inside-Kibana orchestration should
-      // prefer the HTTP route for proper per-space scoping.
+      // single-space deployments. Native Workflow and UI callers use the
+      // HTTP route for request-scoped space resolution.
       const data = await synthesizeAdvisory(
         esClient.asCurrentUser,
         model,

--- a/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/index.ts
@@ -42,15 +42,13 @@ export interface RouteRegistrationDeps {
 }
 
 /**
- * Per the Agent Builder architecture guidance, every domain action exposes
- * a public HTTP route. The skill markdown documents these routes; the
- * orchestrating agent invokes them via `execute_workflow_step` with
- * `kibana-request`. The Agent Builder tool wrappers in
- * `server/agent_builder/tools/` are thin portability shims that call into
- * the same shared services these routes use.
+ * Every domain action exposes a public HTTP route for native Workflows, UI
+ * surfaces, and future ecli callers. Agent Builder tools in
+ * `server/agent_builder/tools/` call the same shared services directly instead
+ * of routing agents through workflow-generated Kibana requests.
  */
 export const registerRoutes = (deps: RouteRegistrationDeps): void => {
-  // Domain-action routes — canonical execution surface.
+  // Domain-action HTTP contracts.
   registerSearchReportsRoute(deps);
   registerIngestReportRoute(deps);
   registerHuntBehaviorRoute(deps);

--- a/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/index.ts
@@ -42,10 +42,11 @@ export interface RouteRegistrationDeps {
 }
 
 /**
- * Every domain action exposes a public HTTP route for native Workflows, UI
- * surfaces, and future ecli callers. Agent Builder tools in
- * `server/agent_builder/tools/` call the same shared services directly instead
- * of routing agents through workflow-generated Kibana requests.
+ * Every domain action exposes a public HTTP route for native Workflows and UI
+ * surfaces. Agent Builder tools in `server/agent_builder/tools/` call the same
+ * shared services directly instead of routing agents through workflow-generated
+ * Kibana requests. When `ecli` becomes available in Agent Builder it will call
+ * these routes directly and the inline tools will be superseded.
  */
 export const registerRoutes = (deps: RouteRegistrationDeps): void => {
   // Domain-action routes — canonical execution surface.

--- a/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/index.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/index.ts
@@ -48,7 +48,7 @@ export interface RouteRegistrationDeps {
  * of routing agents through workflow-generated Kibana requests.
  */
 export const registerRoutes = (deps: RouteRegistrationDeps): void => {
-  // Domain-action HTTP contracts.
+  // Domain-action routes — canonical execution surface.
   registerSearchReportsRoute(deps);
   registerIngestReportRoute(deps);
   registerHuntBehaviorRoute(deps);

--- a/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/search_reports.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/search_reports.ts
@@ -101,10 +101,9 @@ const searchReportsBodySchema = schema.object({
 
 /**
  * Public route exposing the `search_reports` domain action — hybrid
- * semantic + BM25 search over `.kibana-threat-reports-*`. This is the
- * canonical execution surface; the agent calls it via
- * `execute_workflow_step` with `kibana-request`. The Agent Builder tool
- * wrapper delegates to the same `searchReports` service.
+ * semantic + BM25 search over `.kibana-threat-reports-*`. Native HTTP
+ * consumers call this route directly; Agent Builder calls the matching tool,
+ * which delegates to the same `searchReports` service.
  */
 export const registerSearchReportsRoute = ({
   router,

--- a/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/search_reports.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/search_reports.ts
@@ -22,10 +22,7 @@ import {
   type ThreatCategory,
   type ThreatRegion,
 } from '../../../common/threat_intelligence/hub';
-import {
-  buildSearchReportsUiHints,
-  withUiHints,
-} from '../../../common/threat_intelligence/hub';
+import { buildSearchReportsUiHints, withUiHints } from '../../../common/threat_intelligence/hub';
 import { searchReports } from '../services';
 import { resolveCurrentSpaceId } from '../lib/space_filter';
 import type { RouteRegistrationDeps } from '.';

--- a/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/search_reports.ts
+++ b/x-pack/solutions/security/plugins/security_solution/server/threat_intelligence/routes/search_reports.ts
@@ -22,7 +22,10 @@ import {
   type ThreatCategory,
   type ThreatRegion,
 } from '../../../common/threat_intelligence/hub';
-import { buildSearchReportsUiHints, withUiHints } from '../../../common/threat_intelligence/hub';
+import {
+  buildSearchReportsUiHints,
+  withUiHints,
+} from '../../../common/threat_intelligence/hub';
 import { searchReports } from '../services';
 import { resolveCurrentSpaceId } from '../lib/space_filter';
 import type { RouteRegistrationDeps } from '.';


### PR DESCRIPTION
## Summary

The original docs guided agents to call threat intelligence actions via `workflow_execute_step` + `kibana.request`, meaning the agent had to generate workflow YAML to POST to an internal HTTP route. That's a lot of overhead when there are inline tools that call the same shared services directly.

This PR removes all the guidance pointing agents at `workflow_execute_step` + `kibana.request` from comments, tool description strings, and `skill_kibana.md`. No logic changes, just docs.

## Why tools, not routes

The shared service modules in `server/services/` back both the inline tools and the HTTP routes. Agents should use the tools. Native Workflows and UI surfaces use the routes via `kibana.request`.

## The ecli plan

The tools are kept inline (not user-visible) because `ecli` isn't available in Agent Builder yet. When it is, agents will call the HTTP routes directly and the inline tools will go away. They're a temporary bridge, not a permanent surface.